### PR TITLE
Add WooCommerce currency code

### DIFF
--- a/woonuxt.php
+++ b/woonuxt.php
@@ -515,7 +515,7 @@ add_action( 'init', function() {
                 'global_attributes'             => [ 'type' => [ 'list_of' => 'woonuxtOptionsGlobalAttributes' ] ],
                 'publicIntrospectionEnabled'    => [ 'type' => 'String', 'default' => 'off' ],
                 'stripeSettings'                => [ 'type' => 'woonuxtOptionsStripeSettings' ],
-                'currency'                      => [ 'type' => 'String' ],
+                'currencyCode'                  => [ 'type' => 'String' ],
                 'wooCommerceSettingsVersion'    => [ 'type' => 'String' ],
             ],
         ]);
@@ -545,7 +545,7 @@ add_action( 'init', function() {
                 if ( ! function_exists( 'get_woocommerce_currency' ) && function_exists( 'WC' ) ) {
                     require_once WC()->plugin_path() . '/includes/wc-core-functions.php';
                 }
-                $options['currency'] = get_woocommerce_currency();
+                $options['currencyCode'] = get_woocommerce_currency();
 
                 $options['domain'] = $_SERVER['HTTP_HOST'];
                 $options['wooCommerceSettingsVersion'] = WOONUXT_SETTINGS_VERSION;

--- a/woonuxt.php
+++ b/woonuxt.php
@@ -515,6 +515,7 @@ add_action( 'init', function() {
                 'global_attributes'             => [ 'type' => [ 'list_of' => 'woonuxtOptionsGlobalAttributes' ] ],
                 'publicIntrospectionEnabled'    => [ 'type' => 'String', 'default' => 'off' ],
                 'stripeSettings'                => [ 'type' => 'woonuxtOptionsStripeSettings' ],
+                'currency'                      => [ 'type' => 'String' ],
                 'wooCommerceSettingsVersion'    => [ 'type' => 'String' ],
             ],
         ]);
@@ -539,6 +540,12 @@ add_action( 'init', function() {
                 // // Get woocommerce_stripe_settings from wp_options
                 $stripe_settings = get_option( 'woocommerce_stripe_settings' );
                 $options['stripeSettings'] = $stripe_settings;
+
+                // Get WooCommerce currency code
+                if ( ! function_exists( 'get_woocommerce_currency' ) && function_exists( 'WC' ) ) {
+                    require_once WC()->plugin_path() . '/includes/wc-core-functions.php';
+                }
+                $options['currency'] = get_woocommerce_currency();
 
                 $options['domain'] = $_SERVER['HTTP_HOST'];
                 $options['wooCommerceSettingsVersion'] = WOONUXT_SETTINGS_VERSION;


### PR DESCRIPTION
In woonuxt in the page order-summary.vue there is a function formatPrice, where 'EUR' is hardcoded. I think this should be the currency code from the WooCommerce settings. Also I wanted to add structured data to the product page in woonuxt (another pull request incoming ;-)). For this I need the currency code, too.

But I didn't find a way to get the currency code of the WooCommerce settings via Graphql. So I added that to the woonuxt-settings.